### PR TITLE
Fixed bug regarding New lines in input files

### DIFF
--- a/SENNA_utils.c
+++ b/SENNA_utils.c
@@ -130,9 +130,19 @@ void SENNA_fclose(FILE *stream)
   fclose(stream);
 }
 
+
 void* SENNA_malloc(size_t size, size_t nitems)
 {
-  void *res = malloc(size*nitems);
+  void *res = NULL;
+
+  if(size*nitems != 0){
+    /*Actually call calloc for zero'd memory*/
+    res = calloc(1, size*nitems);
+  }
+  else{
+    SENNA_error("attempted to malloc 0 bytes -- exiting");
+  }
+
   if(!res)
     SENNA_error("memory allocation error [%ldGB] -- buy new RAM", size << 30);
   return res;
@@ -143,9 +153,14 @@ void* SENNA_realloc(void *ptr, size_t size, size_t nitems)
 {
   if(size*nitems > 0){
     ptr = realloc(ptr, size*nitems);
-    if(!ptr)
-      SENNA_error("memory allocation error [%ldGB] -- buy new RAM", size << 30);
   }
+  else{
+    SENNA_error("attempted to realloc block to 0 bytes -- exiting");
+  }
+
+  if(!ptr)
+    SENNA_error("memory allocation error [%ldGB] -- buy new RAM", size << 30);
+
   return ptr;
 }
 

--- a/SENNA_utils.c
+++ b/SENNA_utils.c
@@ -135,7 +135,7 @@ void* SENNA_malloc(size_t size, size_t nitems)
 {
   void *res = NULL;
 
-  if(size*nitems != 0){
+  if(size*nitems > 0){
     /*Actually call calloc for zero'd memory*/
     res = calloc(1, size*nitems);
   }

--- a/SENNA_utils.c
+++ b/SENNA_utils.c
@@ -141,9 +141,11 @@ void* SENNA_malloc(size_t size, size_t nitems)
 
 void* SENNA_realloc(void *ptr, size_t size, size_t nitems)
 {
-  ptr = realloc(ptr, size*nitems);
-  if(!ptr)
-    SENNA_error("memory allocation error [%ldGB] -- buy new RAM", size << 30);
+  if(size*nitems > 0){
+    ptr = realloc(ptr, size*nitems);
+    if(!ptr)
+      SENNA_error("memory allocation error [%ldGB] -- buy new RAM", size << 30);
+  }
   return ptr;
 }
 


### PR DESCRIPTION
The bug at hand involved a file which had 2 or more new lines before any other textual data. The reason for the bug was that the tokenizer was not reading anything (ie a new line), so the value of nitems being passed to realloc was 0.

The C standard states:

C90 (C++98)
Otherwise, if size is zero, the memory previously allocated at ptr is deallocated as if a call to free was made, and a null pointer is returned.

C99/C11 (C++11)
If size is zero, the return value depends on the particular library implementation: it may either be a null pointer or some other location that shall not be dereferenced.

Thus, the  if(!ptr) block would always be entered resulting in a SENNA_error: "memory allocation error .."
